### PR TITLE
Render preset only climate controls

### DIFF
--- a/src/card/render/controls.ts
+++ b/src/card/render/controls.ts
@@ -65,7 +65,7 @@ export function renderControls(card: RenderControlsContext): TemplateResult {
       </div>`
     : nothing}
   ${featureEntityObj !== undefined &&
-  (hasClimateOverviewFeature ||
+  ((hasClimateOverviewFeature && !card.hasSeparatedOverviewControls) ||
     hasAdjustTemperatureFeature ||
     hvac.enabled ||
     fan.enabled ||

--- a/src/card/render/controls.ts
+++ b/src/card/render/controls.ts
@@ -69,7 +69,8 @@ export function renderControls(card: RenderControlsContext): TemplateResult {
     hasAdjustTemperatureFeature ||
     hvac.enabled ||
     fan.enabled ||
-    swing.enabled)
+    swing.enabled ||
+    preset.enabled)
     ? html` <div
         class="controls-row"
         style=${styleMap({


### PR DESCRIPTION
Fixes climate controls row rendering for preset-only and separated overview configurations.

The controls row now renders when `climate-preset-modes` is the only enabled control, and avoids rendering an empty row when `climate-overview` is configured with `separate: true`.