### PR TITLE
Sync climate mode controls from entity updates

### DIFF
--- a/src/card/components/climate/climate-fan-modes-control.ts
+++ b/src/card/components/climate/climate-fan-modes-control.ts
@@ -52,14 +52,9 @@ export class GCPClimateFanModesControl extends LitElement {
 
   protected override willUpdate(changedProperties: PropertyValues): void {
     super.willUpdate(changedProperties);
-    if (changedProperties.has("hass") && this.entity) {
-      const oldHass = changedProperties.get("hass") as
-        | HomeAssistant
-        | undefined;
-      const oldStateObj = oldHass?.states[this.entity.entity_id];
-      if (oldStateObj !== this.entity) {
-        this._currentFanMode = this.entity.attributes.fan_mode;
-      }
+
+    if (changedProperties.has("entity") && this.entity) {
+      this._currentFanMode = this.entity.attributes.fan_mode;
     }
   }
 

--- a/src/card/components/climate/climate-hvac-modes-control.ts
+++ b/src/card/components/climate/climate-hvac-modes-control.ts
@@ -56,14 +56,9 @@ export class GCPClimateHvacModesControl extends LitElement {
 
   protected override willUpdate(changedProperties: PropertyValues): void {
     super.willUpdate(changedProperties);
-    if (changedProperties.has("hass") && this.entity) {
-      const oldHass = changedProperties.get("hass") as
-        | HomeAssistant
-        | undefined;
-      const oldStateObj = oldHass?.states[this.entity.entity_id];
-      if (oldStateObj !== this.entity) {
-        this._currentHvacMode = this.entity.state as HvacMode;
-      }
+
+    if (changedProperties.has("entity") && this.entity) {
+      this._currentHvacMode = this.entity.state as HvacMode;
     }
   }
 

--- a/src/card/components/climate/climate-preset-modes-control.ts
+++ b/src/card/components/climate/climate-preset-modes-control.ts
@@ -52,14 +52,9 @@ export class GCPClimatePresetModesControl extends LitElement {
 
   protected override willUpdate(changedProperties: PropertyValues): void {
     super.willUpdate(changedProperties);
-    if (changedProperties.has("hass") && this.entity) {
-      const oldHass = changedProperties.get("hass") as
-        | HomeAssistant
-        | undefined;
-      const oldStateObj = oldHass?.states[this.entity.entity_id];
-      if (oldStateObj !== this.entity) {
-        this._currentPresetMode = this.entity.attributes.preset_mode;
-      }
+
+    if (changedProperties.has("entity") && this.entity) {
+      this._currentPresetMode = this.entity.attributes.preset_mode;
     }
   }
 

--- a/src/card/components/climate/climate-swing-modes-control.ts
+++ b/src/card/components/climate/climate-swing-modes-control.ts
@@ -52,14 +52,9 @@ export class GCPClimateSwingModesControl extends LitElement {
 
   protected override willUpdate(changedProperties: PropertyValues): void {
     super.willUpdate(changedProperties);
-    if (changedProperties.has("hass") && this.entity) {
-      const oldHass = changedProperties.get("hass") as
-        | HomeAssistant
-        | undefined;
-      const oldStateObj = oldHass?.states[this.entity!.entity_id!];
-      if (oldStateObj !== this.entity) {
-        this._currentSwingMode = this.entity.attributes.swing_mode;
-      }
+
+    if (changedProperties.has("entity") && this.entity) {
+      this._currentSwingMode = this.entity.attributes.swing_mode;
     }
   }
 


### PR DESCRIPTION
Fixes climate mode controls syncing their internal pending state from the `entity` property instead of a non-existent `hass` property.

These components receive the Home Assistant state object through `entity`, so checking `changedProperties.has("hass")` could leave the current mode state stale after entity updates.