### PR TITLE
Fix climate fan mode color lookup

### DIFF
--- a/src/card/components/climate/climate-fan-modes-control.ts
+++ b/src/card/components/climate/climate-fan-modes-control.ts
@@ -162,7 +162,7 @@ export class GCPClimateFanModesControl extends LitElement {
     const color =
       mode === "off"
         ? "var(--grey-color)"
-        : FEATURE_PAGE_ICON_COLOR[FEATURE_PAGE_ICON[FEATURE.CLIMATE_FAN_MODES]];
+        : FEATURE_PAGE_ICON_COLOR[FEATURE.CLIMATE_FAN_MODES];
     const isPending =
       this._currentFanMode === mode &&
       this._currentFanMode !== this.entity.attributes.fan_mode;


### PR DESCRIPTION
Fixes the climate fan mode color lookup to use the feature key instead of the SVG icon path.

`FEATURE_PAGE_ICON_COLOR` is keyed by feature names, so using `FEATURE_PAGE_ICON[FEATURE.CLIMATE_FAN_MODES]` returned `undefined` and produced an invalid color value.